### PR TITLE
use abi.encodepacked in ECRecovery.sol

### DIFF
--- a/contracts/ECRecovery.sol
+++ b/contracts/ECRecovery.sol
@@ -69,8 +69,10 @@ library ECRecovery {
     // 32 is the length in bytes of hash,
     // enforced by the type signature above
     return keccak256(
-      "\x19Ethereum Signed Message:\n32",
-      hash
+      abi.encodePacked(
+        "\x19Ethereum Signed Message:\n32",
+        hash
+      )
     );
   }
 }


### PR DESCRIPTION
<!-- 0. 🎉 Thank you for submitting a PR! -->

<!-- 1. **Does this close any open issues?** If so, list them here. If not, remove the `Fixes #` line. -->

Removes the Solidity 0.4.24 warning:

`Warning: This function only accepts a single "bytes" argument. Please use "abi.encodePacked(...)" or a similar function to encode the data.`

<!-- 2. Describe the changes introduced in this pull request -->
<!--    Include any context necessary for understanding the PR's purpose. -->

<!-- 3. Before submitting, please review the following checklist: -->

- [ ] 📘 I've reviewed the [OpenZeppelin Contributor Guidelines](../blob/master/CONTRIBUTING.md)
- [ ] ✅ I've added tests where applicable to test my new functionality.
- [ ] 📖 I've made sure that my contracts are well-documented.
- [ ] 🎨 I've run the JS/Solidity linters and fixed any issues (`npm run lint:all:fix`).
